### PR TITLE
Fixed Yaml::parse returning string

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if (!is_file($file)) {
     return 1;
 }
 
-$config = Yaml::parse(__DIR__ . '/config/configuration.yml.dist');
+$config = Yaml::parse(file_get_contents(__DIR__ . '/config/configuration.yml.dist'));
 
 if (empty($config)) {
     echo 'error! config file does not exist';


### PR DESCRIPTION
In newer versions of Symfony after 2.2 passing a file name will not parse the file but rather return a string with the file name (http://symfony.com/doc/current/components/yaml.html)